### PR TITLE
Correct numerical project IDs

### DIFF
--- a/src/utils/RoadwayProjectManagement.rsc
+++ b/src/utils/RoadwayProjectManagement.rsc
@@ -61,6 +61,7 @@ Macro "Roadway Project Management" (MacroOpts)
   // gplyr's read functions won't work here until it can handle empty files.
   csv_tbl = OpenTable("tbl", "CSV", {output_proj_list, })
   v_projIDs = GetDataVector(csv_tbl + "|", "ProjID", )
+  v_projIDs = String(v_projIDs)
   CloseView(csv_tbl)
   DeleteFile(Substitute(output_proj_list, ".csv", ".DCC", ))
 

--- a/src/utils/RoadwayProjectManagement.rsc
+++ b/src/utils/RoadwayProjectManagement.rsc
@@ -52,9 +52,13 @@ Macro "Roadway Project Management" (MacroOpts)
 
   df = CreateObject("df", proj_list_CAMPO)
   output = df.copy()
-  df = CreateObject("df", proj_list_DCHC)
-  if df.tbl.length >0 then output.bind_rows(df)
-  if output.tbl.length >0 then output.write_csv(output_proj_list)
+  if output.tbl = null
+    then output = CreateObject("df", proj_list_DCHC)
+    else do
+      df = CreateObject("df", proj_list_DCHC)
+      if df.tbl.ProjID > 0 then output.bind_rows(df)
+    end
+  if output.tbl.ProjID > 0 then output.write_csv(output_proj_list)
       else CopyFile(proj_list_CAMPO, output_proj_list)
   
   // Get vector of project IDs from the project list file


### PR DESCRIPTION
This PR corrects two issues in the roadway project manager handling special cases of project lists. The model was crashing when either:

1. When the only project IDs were numbers (and no e.g. A101 was included)
2. When only one roadway project list (CAMPO or DCHC) had project IDs

I split the changes into two separate commits in case we want to cherry pick the fix to the first issue into the v1.3 series.